### PR TITLE
Add the About page, rename brand to László Tuss, and polish the home/timeline UI

### DIFF
--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -8,7 +8,7 @@ const Footer = () => {
     <footer className="max-w-4xl mx-auto w-full px-4 mb-12 pt-8 border-t border-gray-300 dark:border-gray-600">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
         <div>
-          <h2 className="text-xl font-black text-indigo-500">Tuss Co.</h2>
+          <h2 className="text-xl font-black text-indigo-500">László Tuss</h2>
           <p className="text-md font-medium text-gray-500 dark:text-gray-400">
             Budapest, Hungary
           </p>

--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -19,8 +19,8 @@ const Header: FunctionComponent<iHeaderProps> = () => {
           </Link>
         </div>
         <Link href="/">
-          <h1 className="text-indigo-600 dark:text-indigo-400 font-black text-xl whitespace-nowrap">
-            Tuss Co.
+          <h1 className="text-indigo-600 dark:text-indigo-400 font-black text-lg sm:text-xl whitespace-nowrap">
+            László Tuss
           </h1>
         </Link>
         <div className="flex-1 flex gap-2 justify-end">

--- a/src/app/[app]/BackLink.tsx
+++ b/src/app/[app]/BackLink.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export const BackLink = () => {
+  const router = useRouter();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        // Go back through history so the timeline's scroll position is
+        // restored, rather than pushing a fresh "/" that lands at the top.
+        if (window.history.length > 1) router.back();
+        else router.push("/");
+      }}
+      className="inline-flex items-center gap-1.5 text-indigo-500 font-medium mb-6 hover:underline underline-offset-2"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polyline points="15 18 9 12 15 6" />
+      </svg>
+      <span>Back</span>
+    </button>
+  );
+};

--- a/src/app/[app]/page.tsx
+++ b/src/app/[app]/page.tsx
@@ -2,6 +2,7 @@ import { getApp } from "../app";
 import { Metadata } from "next";
 import Link from "next/link";
 import { RoleStamp } from "../RoleStamp";
+import { BackLink } from "./BackLink";
 
 export const generateMetadata = async ({
   params,
@@ -87,25 +88,7 @@ const page = async ({ params }: { params: Promise<{ app: string }> }) => {
 
   return (
     <div className="flex-1 px-4 max-w-3xl w-full mx-auto mt-10 mb-24">
-      <Link
-        href="/"
-        className="inline-flex items-center gap-1.5 text-indigo-500 font-medium mb-6 hover:underline underline-offset-2"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <polyline points="15 18 9 12 15 6" />
-        </svg>
-        <span>Back</span>
-      </Link>
+      <BackLink />
 
       {/* Hero */}
       <div className="flex flex-col sm:flex-row gap-6 items-start">
@@ -156,8 +139,6 @@ const page = async ({ params }: { params: Promise<{ app: string }> }) => {
             style={{ justifyContent: "safe center" }}
           >
             {app.screenshots.map((src, i) => {
-              // The local fallback banner (image.*) isn't a device shot — no
-              // rounded corners for it.
               const isBanner = /\/image\.[a-z0-9]+$/i.test(src);
               return (
                 <img

--- a/src/app/[app]/page.tsx
+++ b/src/app/[app]/page.tsx
@@ -131,14 +131,14 @@ const page = async ({ params }: { params: Promise<{ app: string }> }) => {
         </div>
       </div>
 
-      {/* Screenshots — full-bleed, centered until they overflow */}
+      {/* Screenshots — full-bleed; centered when they fit, scrolling from the
+          start (first one visible) when they overflow. */}
       {app.screenshots.length > 0 && (
-        <div className="mt-10 relative left-[calc(50%-50vw)] w-screen">
-          <div
-            className="flex gap-4 overflow-x-auto px-5 snap-x snap-mandatory scrollbar-none"
-            style={{ justifyContent: "safe center" }}
-          >
+        <div className="mt-10 relative left-[calc(50%-50vw)] w-screen overflow-x-auto scrollbar-none snap-x px-5 sm:px-8">
+          <div className="flex gap-4 w-max mx-auto">
             {app.screenshots.map((src, i) => {
+              // The local fallback banner (image.*) isn't a device shot — no
+              // rounded corners for it.
               const isBanner = /\/image\.[a-z0-9]+$/i.test(src);
               return (
                 <img
@@ -146,7 +146,7 @@ const page = async ({ params }: { params: Promise<{ app: string }> }) => {
                   src={src}
                   alt={`${app.name} screenshot ${i + 1}`}
                   loading="lazy"
-                  className={`h-[440px] w-auto shadow-md shrink-0 snap-start ${
+                  className={`h-[440px] w-auto max-w-none object-contain shadow-md shrink-0 snap-start ${
                     isBanner ? "" : "rounded-2xl"
                   }`}
                 />

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,35 +1,179 @@
-import { FunctionComponent } from "react";
+interface iRole {
+  title: string;
+  company: string;
+  period: string;
+  points: string[];
+}
 
-interface ipageProps {}
+const experience: iRole[] = [
+  {
+    title: "Senior iOS Developer",
+    company: "Teleprompter Kft.",
+    period: "Dec 2022 – Mar 2025",
+    points: [
+      "Restructured and modernized a large legacy codebase while keeping compatibility across many device and OS generations.",
+      "Ported several apps to native macOS, with platform-specific features and interfaces.",
+      "Redesigned the architecture around SwiftUI and Combine — cutting boilerplate and breaking up overgrown components.",
+      "Built new VIPER submodules and collaborated across international teams through code review and pull requests.",
+    ],
+  },
+  {
+    title: "Indie App Developer",
+    company: "Self-employed · Since 2017",
+    period: "Since 2017",
+    points: [
+      "Image-manipulation apps built with CoreML, CoreImage and the Vision framework.",
+      "Repackaged my own frameworks as Swift Package Manager modules with Bitrise CI.",
+      "iOS app extensions using shared containers and iCloud-synced data.",
+      "Continuously adopt new Apple frameworks and beta APIs to keep products future-ready.",
+    ],
+  },
+  {
+    title: "Lead iOS Developer",
+    company: "beam.space Kft.",
+    period: "Apr 2018 – Mar 2021",
+    points: [
+      "Mentored junior developers and led architectural decisions for cross-platform interoperability.",
+      "Built real-time AR scenes with on-demand model and texture fetching against complex data models.",
+      "Optimized CPU and memory for multiple 2K streams feeding Metal shaders, keeping older iPads responsive.",
+      "Kept data consistent between native ARKit / SceneKit / OpenCV / Metal and a React Native UI.",
+    ],
+  },
+  {
+    title: "Freelance iOS Developer",
+    company: "laszlotuss.com",
+    period: "Mar 2017 – Jan 2018",
+    points: [
+      "Rewrote the Italian Food travel guide (Blue Guides) with a shared iOS, macOS and watchOS interface.",
+      "Delivered an Arizona-based real-estate app and mentored smaller in-house projects.",
+      "Contributed to an internal tool for McKinsey, and launched my first App Store app under my own name.",
+    ],
+  },
+  {
+    title: "iOS Developer & Co-owner",
+    company: "Tappointment Kft.",
+    period: "Sep 2012 – Nov 2016",
+    points: [
+      "Co-founded the startup and drove the mobile product from idea to App Store launch.",
+      "Designed a scalable iOS architecture for appointment-scheduling systems.",
+      "Shipped customer apps and internal tools, including Philips Hue control (HUE Power) and offline navigation (Blazing Saddles SF).",
+    ],
+  },
+];
 
-const page: FunctionComponent<ipageProps> = () => {
+const skills: [string, string][] = [
+  ["Languages", "Swift, SwiftUI, Objective-C, Python, TypeScript (React Native)"],
+  ["Architecture", "MVVM, MVC, VIPER, modularization"],
+  ["Data", "Core Data, Realm, Firebase, CloudKit, iCloud, MySQL"],
+  ["Tooling", "Xcode Cloud, Bitrise, SPM, CocoaPods, Git, SwiftLint, SwiftFormat, Instruments"],
+  ["Design", "Figma, Sketch, Affinity Designer, Photoshop"],
+  ["Process", "Scrum, Kanban, Jira, Trello, Notion, Basecamp"],
+];
+
+const education: [string, string, string][] = [
+  [
+    "Computer Science",
+    "Eötvös Loránd University — Faculty of Informatics, Budapest",
+    "2012 – 2018",
+  ],
+  [
+    "Software Developer",
+    "BMSZC Petrik Lajos Technical School, Budapest",
+    "2011 – 2012",
+  ],
+];
+
+const SectionHeading = ({ children }: { children: React.ReactNode }) => (
+  <h2 className="mt-14 mb-5 text-sm font-bold uppercase tracking-widest text-indigo-500">
+    {children}
+  </h2>
+);
+
+const page = () => {
   return (
-    <div className="flex-1 px-4 max-w-2xl w-full mx-auto pt-16 text-3xl text-gray-600 dark:text-gray-400 leading-relaxed">
-      <p>
-        <strong className="text-gray-700 dark:text-gray-300">
-          Hi 👋🏻 I&apos;m László.
-        </strong>{" "}
-        I&apos;m an indie iOS developer based in Budapest, Hungary, and
-        I&apos;ve been shipping apps to the App Store since 2014.
-      </p>
-      <p className="mt-6 text-2xl">
-        Over the years I&apos;ve built dozens of iOS apps — my own indie
-        projects, a booking startup I co-owned (Tappointment), and contract
-        work for clients around the world, from Teleprompter.com to a furniture
-        configurator for Wittmann. They span stickers and iMessage, utilities,
-        productivity, finance and photo &amp; video.
-      </p>
-      <p className="mt-6 text-2xl">
-        I work mostly in Swift, with a long history of Objective-C, and I enjoy
-        the platform&apos;s newer corners — Live Activities, Picture-in-Picture,
-        the Dynamic Island, widgets and the Apple Watch. I like taking an idea
-        all the way from a sketch to the App Store.
-      </p>
+    <div className="flex-1 px-4 max-w-2xl w-full mx-auto pt-16 pb-24">
+      {/* Intro */}
       <img
         src="/profile.jpg"
         alt="László Tuss"
-        className="w-full mt-10 max-w-lg mx-auto mb-24 rounded-[32px]"
+        className="w-28 h-28 rounded-[28px] shadow-md mb-6"
       />
+      <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-100">
+        Hi 👋🏻 I&apos;m László.
+      </h1>
+      <p className="mt-4 text-lg leading-relaxed text-gray-600 dark:text-gray-400">
+        An iOS developer with more than 10 years of experience designing,
+        building and maintaining mobile apps for startups, international
+        companies and my own indie projects. I work in Swift, SwiftUI and
+        Objective-C with deep knowledge of the iOS frameworks and app
+        architecture — system optimization, modularization and product
+        lifecycle. I enjoy mentoring junior developers, working with
+        cross-functional teams, and translating technical solutions for
+        technical and non-technical audiences alike.
+      </p>
+
+      {/* Experience */}
+      <SectionHeading>Experience</SectionHeading>
+      <div className="flex flex-col gap-8">
+        {experience.map((role) => (
+          <div key={role.title + role.period}>
+            <div className="flex flex-wrap items-baseline justify-between gap-x-3">
+              <h3 className="text-lg font-bold text-gray-800 dark:text-gray-200">
+                {role.title}
+              </h3>
+              <span className="text-sm font-medium text-gray-400 dark:text-gray-500">
+                {role.period}
+              </span>
+            </div>
+            <p className="font-medium text-indigo-500">{role.company}</p>
+            <ul className="mt-2 list-disc pl-5 space-y-1 text-gray-600 dark:text-gray-400 leading-relaxed">
+              {role.points.map((point, i) => (
+                <li key={i}>{point}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      {/* Skills */}
+      <SectionHeading>Skills</SectionHeading>
+      <dl className="flex flex-col gap-3">
+        {skills.map(([group, items]) => (
+          <div key={group} className="sm:flex sm:gap-3">
+            <dt className="font-semibold text-gray-700 dark:text-gray-300 sm:w-32 sm:shrink-0">
+              {group}
+            </dt>
+            <dd className="text-gray-600 dark:text-gray-400">{items}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {/* Education */}
+      <SectionHeading>Education</SectionHeading>
+      <div className="flex flex-col gap-4">
+        {education.map(([degree, school, period]) => (
+          <div
+            key={degree}
+            className="flex flex-wrap items-baseline justify-between gap-x-3"
+          >
+            <div>
+              <p className="font-bold text-gray-800 dark:text-gray-200">
+                {degree}
+              </p>
+              <p className="text-gray-600 dark:text-gray-400">{school}</p>
+            </div>
+            <span className="text-sm font-medium text-gray-400 dark:text-gray-500">
+              {period}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Languages */}
+      <SectionHeading>Languages</SectionHeading>
+      <p className="text-gray-600 dark:text-gray-400">
+        Hungarian (native) · English (B2)
+      </p>
     </div>
   );
 };

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -7,19 +7,28 @@ const page: FunctionComponent<ipageProps> = () => {
     <div className="flex-1 px-4 max-w-2xl w-full mx-auto pt-16 text-3xl text-gray-600 dark:text-gray-400 leading-relaxed">
       <p>
         <strong className="text-gray-700 dark:text-gray-300">
-          Hi, 👋🏻 I&apos;m László.
+          Hi 👋🏻 I&apos;m László.
         </strong>{" "}
-        Lorem ipsum, dolor sit amet consectetur adipisicing elit. Fuga ut
-        voluptas consectetur?
+        I&apos;m an indie iOS developer based in Budapest, Hungary, and
+        I&apos;ve been shipping apps to the App Store since 2014.
       </p>
-      <p className="mt-4 text-2xl">
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempora
-        similique illum nobis eveniet. Voluptatibus, praesentium ea.
+      <p className="mt-6 text-2xl">
+        Over the years I&apos;ve built dozens of iOS apps — my own indie
+        projects, a booking startup I co-owned (Tappointment), and contract
+        work for clients around the world, from Teleprompter.com to a furniture
+        configurator for Wittmann. They span stickers and iMessage, utilities,
+        productivity, finance and photo &amp; video.
+      </p>
+      <p className="mt-6 text-2xl">
+        I work mostly in Swift, with a long history of Objective-C, and I enjoy
+        the platform&apos;s newer corners — Live Activities, Picture-in-Picture,
+        the Dynamic Island, widgets and the Apple Watch. I like taking an idea
+        all the way from a sketch to the App Store.
       </p>
       <img
         src="/profile.jpg"
-        alt="Laszlo tuss"
-        className="w-full mt-8 max-w-lg mx-auto mb-24"
+        alt="László Tuss"
+        className="w-full mt-10 max-w-lg mx-auto mb-24 rounded-[32px]"
       />
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,16 +67,14 @@ export default async function Home() {
                         </h3>
                         <RoleStamp role={app.role} />
                       </div>
-                      {app.company && (
+                      {(app.genre || app.company) && (
                         <p className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
-                          {app.company}
+                          {[app.genre, app.company].filter(Boolean).join(" · ")}
                         </p>
                       )}
-                      {(app.genre || app.description) && (
+                      {app.description && (
                         <p className="text-sm text-gray-500 dark:text-gray-400 line-clamp-2">
-                          {[app.genre, app.description]
-                            .filter(Boolean)
-                            .join(" · ")}
+                          {app.description}
                         </p>
                       )}
                     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,18 +8,20 @@ export default async function Home() {
 
   return (
     <>
-      <div className="flex flex-col items-center mb-20 text-center px-4">
+      <div className="flex flex-col items-center text-center md:flex-row md:justify-center md:items-center md:text-left md:gap-10 mt-24 mb-20 px-4">
         <img
-          className="bg-gray-700 w-36 rounded-[32px] mt-24"
+          className="bg-gray-700 w-36 rounded-[32px] shrink-0"
           src="/profile.jpg"
           alt="László Tuss"
         />
-        <h2 className="text-4xl font-bold mt-12 text-indigo-500">
-          Hi, I am László 👋
-        </h2>
-        <p className="mt-2 text-lg font-medium text-gray-500 dark:text-gray-400">
-          I am an iOS developer & I build indie applications
-        </p>
+        <div className="mt-12 md:mt-0">
+          <h2 className="text-4xl font-bold text-indigo-500">
+            Hi, I am László 👋
+          </h2>
+          <p className="mt-2 text-lg font-medium text-gray-500 dark:text-gray-400">
+            I am an iOS developer & I build indie applications
+          </p>
+        </div>
       </div>
 
       <section className="flex-1 max-w-2xl w-full mx-auto px-4 pb-24">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,13 +8,13 @@ export default async function Home() {
 
   return (
     <>
-      <div className="flex flex-col items-center text-center md:flex-row md:justify-center md:items-center md:text-left md:gap-10 mt-24 mb-20 px-4">
+      <div className="max-w-2xl w-full mx-auto flex flex-col items-center text-center md:flex-row md:items-center md:text-left md:gap-8 mt-24 mb-20 px-4">
         <img
           className="bg-gray-700 w-36 rounded-[32px] shrink-0"
           src="/profile.jpg"
           alt="László Tuss"
         />
-        <div className="mt-12 md:mt-0">
+        <div className="mt-12 md:mt-0 md:flex-1">
           <h2 className="text-4xl font-bold text-indigo-500">
             Hi, I am László 👋
           </h2>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,9 @@ export default async function Home() {
             Hi, I am László 👋
           </h2>
           <p className="mt-2 text-lg font-medium text-gray-500 dark:text-gray-400">
-            I am an iOS developer & I build indie applications
+            Experienced iOS Developer with over 10 years in mobile app
+            development, working across freelance projects, startups, and
+            established companies.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## What changed

A set of content and UI-polish improvements, each as its own commit:

- **About page** — filled out from my CV: intro bio, Experience, Skills, Education, and Languages. No email/phone by request (`a45c829`, `d152014`).
- **Brand rename** — "Tuss Co." → "László Tuss" across the header, footer, and metadata (`2a0aa9b`).
- **Home hero** — horizontal on desktop / stacked on mobile, width aligned with the timeline, and a reworded subtitle (`2db4fc4`, `c1fb417`, `31c8964`).
- **Timeline card** — show `Category · Company` on one line, matching the app detail page byline, with the description on its own line (`b939c09`).
- **Screenshot strip** — fixed centering, side padding, first-screenshot-visible-on-load, and the fallback banner aspect ratio (`f3a0d1c`).
- **Back navigation** — going back from an app now restores the timeline scroll position via a client-side `BackLink` (`fa7bfc3`).

## Why

Rounds out the portfolio with a real About page, consistent personal branding, and a number of layout fixes that make the timeline and app detail pages feel polished on both desktop and mobile.

## Reviewer notes

- 6 files changed: `about/page.tsx`, `page.tsx`, `[app]/page.tsx`, `[app]/BackLink.tsx` (new), `Header.tsx`, `Footer.tsx`.
- `BackLink` is a client component using `router.back()` (falls back to `/` when there's no history), so timeline scroll is preserved on return.
- Company on the timeline/detail byline comes from the iTunes `artistName` ("Laszlo Tuss", unaccented); the header/footer brand uses the accented "László Tuss". Can add per-app `company` overrides in `apps.json` if we want the accent on cards too.
- `next build` passes (only the pre-existing `<img>` → `next/image` lint warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)